### PR TITLE
Gitignores for ctags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 *~
+.tags*
+.TAGS*
+tags
+TAGS
+.ctags
+ctags.cnf


### PR DESCRIPTION
I find it very useful to use ctags and/or ctags-aware editors to navigate through the code, so I added some ctags' gitignores. I hope you find them useful too.