### PR TITLE
Better world lists

### DIFF
--- a/mscs
+++ b/mscs
@@ -83,13 +83,17 @@ Options:
   enable <world>
     Enable a disabled world server.
 
-  list <option>
+  ls <option>
     Display a list of worlds.
     Options:
       enabled   Display a list of enabled worlds, default.
       disabled  Display a list of disabled worlds.
       running   Display a list of running worlds.
       stopped   Display a list of stopped worlds.
+    If no option, 'enabled' is assumed.
+
+  list <option>
+    Same as 'ls' but more detailed.
 
   status <world>
     Display the status of the Minecraft world server.  Display the status of
@@ -280,6 +284,13 @@ BACKUP_DURATION=15
 
 # Length in days that logs survive.
 LOG_DURATION=15
+
+
+# Listing options
+# ---------------------------------------------------------------------------
+
+# Server properties for detailed listing (list).
+DETAILED_LISTING_PROPERTIES="motd server-ip server-port max-players level-type online-mode"
 
 
 # Mirror Image Options
@@ -1856,11 +1867,36 @@ case "$1" in
           fi
         done
       ;;
-      *)
+      "")
         WORLDS=$(getEnabledWorlds)
       ;;
+      *)
+        echo "Unknown list option: $2."
+        echo "  Try '$0 help' for help."
+        exit 1
+      ;;
     esac
-    echo $WORLDS
+
+    case "$1" in
+      ls)
+        # Simple list
+        for WORLD in $WORLDS; do
+          WPORT=$(getPropertiesValue "$WORLD" server-port "")
+          echo "  $WORLD: $WPORT"
+        done
+      ;;
+      list)
+        # Detailed list
+        for WORLD in $WORLDS; do
+          echo "  $WORLD:"
+          for PROP in $DETAILED_LISTING_PROPERTIES; do
+            echo -n "      "
+            echo -n "$PROP="
+            getPropertiesValue "$WORLD" "$PROP" ""
+          done
+        done
+      ;;
+    esac
   ;;
   status|show)
     checkPermission

--- a/mscs
+++ b/mscs
@@ -525,6 +525,31 @@ getDisabledWorlds() {
 }
 
 # ---------------------------------------------------------------------------
+# Grab the list of all available worlds.
+#
+# @return The list of all available worlds.
+# ---------------------------------------------------------------------------
+getAvailableWorlds() {
+  echo $(getEnabledWorlds) $(getDisabledWorlds)
+}
+
+# ---------------------------------------------------------------------------
+# Check to see if the world is enabled.
+#
+# @param 1 The world of interest.
+# @return A 1 if the world is enabled, a 0 otherwise.
+# ---------------------------------------------------------------------------
+isWorldEnabled() {
+  local WORLDS
+  WORLDS=$(getEnabledWorlds)
+  if [ -n "$1" ] && [ $(listContains "$1" "$WORLDS") -eq 1 ]; then
+    echo 1
+  else
+    echo 0
+  fi
+}
+
+# ---------------------------------------------------------------------------
 # Get the value of a key from the provided file.
 #
 # @param 1 The file containing the key/value combo.
@@ -588,7 +613,11 @@ getEULAValue() {
 # ---------------------------------------------------------------------------
 getPropertiesValue() {
   local PROPERTY_FILE
-  PROPERTY_FILE=$WORLDS_LOCATION/$1/server.properties
+  if [ -f "$WORLDS_LOCATION/$1/server.properties" ]; then
+    PROPERTY_FILE="$WORLDS_LOCATION/$1/server.properties"
+  else
+    PROPERTY_FILE="$DISABLED_WORLDS_LOCATION/$1/server.properties"
+  fi
   getValue "$PROPERTY_FILE" "$2" "$3"
 }
 
@@ -1868,7 +1897,7 @@ case "$1" in
         done
       ;;
       "")
-        WORLDS=$(getEnabledWorlds)
+        WORLDS=$(getAvailableWorlds)
       ;;
       *)
         echo "Unknown list option: $2."
@@ -1882,16 +1911,25 @@ case "$1" in
         # Simple list
         for WORLD in $WORLDS; do
           WPORT=$(getPropertiesValue "$WORLD" server-port "")
-          echo "  $WORLD: $WPORT"
+          printf "  $WORLD: $WPORT"
+          if [ $(isWorldEnabled "$WORLD") -eq 0 ]; then
+            printf ' (disabled)\n'
+          else
+            printf '\n'
+          fi
         done
       ;;
       list)
         # Detailed list
         for WORLD in $WORLDS; do
-          echo "  $WORLD:"
+          printf "  $WORLD:"
+          if [ $(isWorldEnabled "$WORLD") -eq 0 ]; then
+            printf ' (disabled)\n'
+          else
+            printf '\n'
+          fi
           for PROP in $DETAILED_LISTING_PROPERTIES; do
-            echo -n "      "
-            echo -n "$PROP="
+            printf "    $PROP="
             getPropertiesValue "$WORLD" "$PROP" ""
           done
         done

--- a/mscs.completion
+++ b/mscs.completion
@@ -1,5 +1,9 @@
 MSCS=mscs
 
+list_worlds() {
+  $MSCS ls $1 | sed -n '/:/{s/^ *//;s/:.*$//;p}'
+}
+
 _mscs() {
   local OPTS WORLDS
   COMPREPLY=()
@@ -19,20 +23,20 @@ _mscs() {
   elif [ $COMP_CWORD -eq 2 ]; then
     case ${COMP_WORDS[COMP_CWORD-1]} in
       start)
-        WORLDS=$($MSCS list stopped)
+        WORLDS=$(list_worlds stopped)
         COMPREPLY=($(compgen -W "$WORLDS" -- ${COMP_WORDS[COMP_CWORD]}))
       ;;
       stop|force-stop|restart|force-restart|send|console)
-        WORLDS=$($MSCS list running)
+        WORLDS=$(list_worlds running)
         COMPREPLY=($(compgen -W "$WORLDS" -- ${COMP_WORDS[COMP_CWORD]}))
       ;;
       delete|remove|disable|status|show|sync|send|watch|logrotate| \
       backup|map|overviewer|list-backups|restore-backup)
-        WORLDS=$($MSCS list enabled)
+        WORLDS=$(list_worlds enabled)
         COMPREPLY=($(compgen -W "$WORLDS" -- ${COMP_WORDS[COMP_CWORD]}))
       ;;
       enable)
-        WORLDS=$($MSCS list disabled)
+        WORLDS=$(list_worlds disabled)
         COMPREPLY=($(compgen -W "$WORLDS" -- ${COMP_WORDS[COMP_CWORD]}))
       ;;
       ls|list)


### PR DESCRIPTION
I always check used ports in the config files when adding a new world, so I changed "mscs ls" to print the used port of every server/world.

'ls' was not documented in 'mscs help' so changed that too.

I modified 'list' option to generate a more detailed list including some server.properties parameters. The modifications were easy thanks to the rich set of procedures already implemented in the script. The exact list of properties shown is configured through a global variable. It is intended to give the user a general view of the configured servers and major options in use.

Now, a wrong <option> in 'mscs list <option>' will abort with an error message instead of listing enabled worlds. No option will still print an enabled world's listing.

There are a couple of changes that I also want to make in the listings in case you find them right for master:

1) Change 'mscs ls|list' behaviour with no option to list both enabled and disabled worlds.
2) Include the enabled/disabled state of the world in the listing.

I hope you find these changes ready for integration. If not, please let me know.