### PR TITLE
Move 'usage' info to a function

### DIFF
--- a/mscs
+++ b/mscs
@@ -48,7 +48,8 @@
 # Script Usage
 # ---------------------------------------------------------------------------
 
-USAGE=$(cat <<EOF
+usage() {
+  cat <<EOF
 Usage:  $0 <option>
 
 Options:
@@ -136,9 +137,9 @@ Options:
   update <world>
     Update the server software for the Minecraft world server.  Update
     server software for all worlds by default.
-
 EOF
-)
+}
+
 
 # Override Global Variables
 # ---------------------------------------------------------------------------
@@ -2346,12 +2347,12 @@ case "$1" in
   usage|help)
     printf "Minecraft Server Control Script\n"
     printf "\n"
-    printf "$USAGE\n"
+    usage
   ;;
   *)
     printf "Error in command line usage.\n"
     printf "\n"
-    printf "$USAGE\n"
+    usage
     exit 1
   ;;
 esac


### PR DESCRIPTION
Improves eficiency avoiding to load the usage text in memory three times.

Usage text was in the program code (static copy) and was assigned to a variable (dynamic copy). It was printed from printf generating a new string (dynamic copy).

Now the usage text is just cat'ed from program code to stdout.

Maybe not a huge improvement but an easy one.